### PR TITLE
Add async version and bug fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,13 @@ categories = [
 
 [dependencies]
 embedded-storage = "0.3.0"
+embedded-storage-async = { version = "0.4.1", optional = true }
 defmt = { version = "0.3", optional = true }
 
 [features]
 defmt = [
       "dep:defmt",
+]
+async = [
+      "embedded-storage-async",
 ]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An implementation of the Nordic nRF DFU protocol in Rust that can be used in a `
 
 The intention is that any transport (BLE, UART, USB) can use this crate for decoding the request, processing the request and encoding the response for the protocol.
 
-You can use any flash device that implements the embedded-storage traits as the target.
+You can use any flash device that implements the embedded-storage traits for sync or embedded-storage-async traits for async version as the target. Use feature `async` to enable async version.
 
 It does not support updating more than one firmware type for each `DfuTarget` instance at the moment. 
 

--- a/src/dfu.rs
+++ b/src/dfu.rs
@@ -465,7 +465,7 @@ impl<const MTU: usize> DfuTarget<MTU> {
                 obj.crc.add(data);
                 obj.offset += data.len() as u32;
 
-                let mut response = DfuResponse::new(request, DfuResult::Success);
+                let mut response = DfuResponse::new(DfuRequest::Crc, DfuResult::Success);
                 if self.crc_receipt_interval > 0 {
                     self.receipt_count += 1;
                     if self.receipt_count == self.crc_receipt_interval {
@@ -718,7 +718,7 @@ impl<const MTU: usize> DfuTarget<MTU> {
                 obj.crc.add(data);
                 obj.offset += data.len() as u32;
 
-                let mut response = DfuResponse::new(request, DfuResult::Success);
+                let mut response = DfuResponse::new(DfuRequest::Crc, DfuResult::Success);
                 if self.crc_receipt_interval > 0 {
                     self.receipt_count += 1;
                     if self.receipt_count == self.crc_receipt_interval {


### PR DESCRIPTION
According to Nordic Documentation for [SDK v17.x.x](https://infocenter.nordicsemi.com/topic/sdk_nrf5_v17.1.0/lib_dfu_transport.html), the response of the Write command must be None or if PRN is enabled, it should send CRC response.
Another feature which is added is async version of this crate.
All of the changes are tested.
Please merge it.